### PR TITLE
Pass anything in the 'options' field to esnext

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ export default function esnext (options = {}) {
 			if ( extensions.indexOf(extname( id )) === -1) return null;
 			if ( !firstpass.test( code ) ) return null;
 
-			const converted = convert(code);
+			const converted = convert(code, options.options);
 
 			return { code: converted.code, map: converted.map};
 		},


### PR DESCRIPTION
I would like to use rollup-plugin-esnext to convert commonjs modules to es6 instead of the rollup-plugin-commonjs (since it can't handle a situation with circular dependencies in a package I'm using).

The problem is that it chokes on a dependency like react because I can't whitelist/blacklist any esnext plugins.

Looking at the code, I think [this line](https://github.com/jvilk/rollup-plugin-esnext/blob/master/src/index.js#L46) should pass along any extra options the user provides.

